### PR TITLE
Created SaveAreaDatabase service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SRV_FILES
     "srv/SetPose.srv"
     "srv/StartSvoRec.srv"
     "srv/SetROI.srv"
+    "srv/SaveAreaDatabase.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/srv/SaveAreaDatabase.srv
+++ b/srv/SaveAreaDatabase.srv
@@ -1,0 +1,7 @@
+# Save Area Database from positional tracking 
+
+# File path where the database is to be saved
+string file_path
+---
+bool success   # indicate successful run of service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
### Pull Request Description

**Overview:** 
Enhances `zed_interfaces` by adding `GetAreaDatabase`, a new service facilitating area database retrieval via the ZED ROS 2 wrapper.

**Changes:**

- Added `GetAreaDatabase` service definition to `zed_interfaces`.
- Implemented service call handling in `zed_ros2_wrapper` to process requests and interact with ZED SDK.

**Details:**

- **New Service (`GetAreaDatabase`):**
  - Defined in `zed_interfaces` for ROS 2 nodes to request ZED camera area databases.
  - Enhances interaction capabilities for localization and mapping tasks.

- **Implementation in `zed_ros2_wrapper`:**
  - Handles requests, utilizes ZED SDK for database retrieval, and sends responses to clients.

**Usage:**

- Enables dynamic area database retrieval from ZED cameras in ROS 2 applications.
- Enhances functionality for spatial awareness and mapping tasks.

**Impact:**

- Improves ZED camera integration in ROS 2, enhancing robotic perception and localization.
- Standardizes access to area databases, promoting interoperability across projects.

**Testing:**

- Tested on Stereolabs ZED Box with ZEDX stereo camera.
- Test environment used Isaac ROS docker container running Ubuntu 22.04.

**Contributor Notes:**

- Aligns with efforts to expand ZED ROS 2 wrapper functionality.
- Welcomes feedback for further optimization and refinement.