### PR TITLE
Add skeleton keypoint confidence to Object.msg

### DIFF
--- a/msg/Object.msg
+++ b/msg/Object.msg
@@ -66,3 +66,6 @@ zed_msgs/Skeleton2D skeleton_2d
 
 # 3D Person skeleton in world frame
 zed_msgs/Skeleton3D skeleton_3d
+
+# Confidence levels for each of the skeleton keypoints
+float32[70] skeleton_keypoint_confidence


### PR DESCRIPTION
This enables access to the confidence levels provided by the ZED SDK, allowing for applications like skeleton-based gaze detectors and potentially benefiting other applications as well.

_Note: This change is a prerequisite for changes in the ZED ROS2 Wrapper that forward the confidence data from the SDK to this message._